### PR TITLE
Add ChainRulesCore rrule support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "0.1.0"
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+ChainRulesCore = "ccc36cab-3b5c-5c97-8360-47317d29d022"
 
 [compat]
 MacroTools = "0.5"
 julia = "1.7"
+ChainRulesCore = "1"
 
 [extras]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/NonlinearEquations.jl
+++ b/src/NonlinearEquations.jl
@@ -3,6 +3,7 @@ module NonlinearEquations
 include("Calculus.jl")
 import MacroTools
 import SparseArrays
+import ChainRulesCore
 
 function codegen_addterm_residuals(equationnum, term)
 	return quote 
@@ -111,8 +112,13 @@ macro equations(fundef)
 end
 
 function equations(fundef::Expr, macroexpand_module, dont_differentiate_syms::Array{Symbol, 1})
-	dict = MacroTools.splitdef(fundef)
-	original_body = macroexpand(macroexpand_module, dict[:body])
+        dict = MacroTools.splitdef(fundef)
+        original_args_list = copy(dict[:args])
+        original_kwargs_list = copy(dict[:kwargs])
+        original_whereparams = get(dict, :whereparams, nothing)
+        original_arg_names = map(arg->MacroTools.splitarg(arg)[1], original_args_list)
+        diff_arg_names = [MacroTools.splitarg(a)[1] for a in filter(a->!(MacroTools.splitarg(a)[1] in dont_differentiate_syms), original_args_list)]
+        original_body = macroexpand(macroexpand_module, dict[:body])
 	#generate the code for computing the residuals
 	body_residuals = MacroTools.postwalk(x->replacenumequations(x, :(residuals = zeros(numequations))), original_body)
 	body_residuals = MacroTools.postwalk(x->replaceaddterm(x, codegen_addterm_residuals), body_residuals)
@@ -160,20 +166,52 @@ function equations(fundef::Expr, macroexpand_module, dont_differentiate_syms::Ar
 	end
 	#generate the in-place versions of the jacobian
 	pushfirst!(dict[:args], :___jacobian_storage___)
-	for arg in filter(x->!(x in dont_differentiate_syms), dict[:args])
-		arg_name = MacroTools.splitarg(arg)[1]
-		body_inplacejacobian = MacroTools.postwalk(x->replacenumequations(x, :()), original_body)
-		body_inplacejacobian = MacroTools.postwalk(x->replaceaddterm(x, (eqnum, term)->codegen_addterm_inplacejacobian(eqnum, term, arg_name)), body_inplacejacobian)
-		dict[:name] = Symbol(original_name, :_, arg_name, :!)
-		dict[:body] = quote
-			fill!(SparseArrays.nonzeros(___jacobian_storage___), zero(eltype($arg)))
-			$body_inplacejacobian
-			return nothing
-		end
-		push!(q_result.args, :($(esc(MacroTools.combinedef(dict)))))
-	end
-	#display(MacroTools.prettify(q_result))
-	return q_result
+        for arg in filter(x->!(x in dont_differentiate_syms), dict[:args])
+                arg_name = MacroTools.splitarg(arg)[1]
+                body_inplacejacobian = MacroTools.postwalk(x->replacenumequations(x, :()), original_body)
+                body_inplacejacobian = MacroTools.postwalk(x->replaceaddterm(x, (eqnum, term)->codegen_addterm_inplacejacobian(eqnum, term, arg_name)), body_inplacejacobian)
+                dict[:name] = Symbol(original_name, :_, arg_name, :!)
+                dict[:body] = quote
+                        fill!(SparseArrays.nonzeros(___jacobian_storage___), zero(eltype($arg)))
+                        $body_inplacejacobian
+                        return nothing
+                end
+                push!(q_result.args, :($(esc(MacroTools.combinedef(dict)))))
+        end
+
+        #generate the ChainRulesCore rrule for the residuals
+        dict[:args] = [:(::typeof($(Symbol(original_name, :_residuals)))), original_args_list...]
+        dict[:kwargs] = original_kwargs_list
+        dict[:whereparams] = original_whereparams
+        dict[:name] = :(ChainRulesCore.rrule)
+
+        call_residuals = Expr(:call, Symbol(original_name, :_residuals), original_arg_names..., original_kwargs_list)
+        pullback_ex = Expr(:block)
+        for name in original_arg_names
+                if name in diff_arg_names
+                        jac_call = Expr(:call, Symbol(original_name, :_, name), original_arg_names..., original_kwargs_list)
+                        push!(pullback_ex.args, :(d_$(name) = transpose($jac_call) * ȳ))
+                else
+                        push!(pullback_ex.args, :(d_$(name) = ChainRulesCore.NoTangent()))
+                end
+        end
+        retvals = [:ChainRulesCore.NoTangent()]
+        for name in original_arg_names
+                push!(retvals, Symbol(:d_, name))
+        end
+        push!(retvals, :(ChainRulesCore.NoTangent()))
+        push!(pullback_ex.args, Expr(:return, Expr(:tuple, retvals...)))
+
+        dict[:body] = quote
+                y = $call_residuals
+                function pullback(ȳ)
+                        $pullback_ex
+                end
+                return y, pullback
+        end
+        push!(q_result.args, :($(esc(MacroTools.combinedef(dict)))))
+        #display(MacroTools.prettify(q_result))
+        return q_result
 end
 
 function escapesymbols(expr, symbols)


### PR DESCRIPTION
## Summary
- support differentiating residual functions via rrules
- expose ChainRulesCore in project dependencies

## Testing
- `julia --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687577170e30832eb5102c46bb66deca